### PR TITLE
Changing scrollbar color to dark to better match the dark UI

### DIFF
--- a/apps/web/src/app.postcss
+++ b/apps/web/src/app.postcss
@@ -13,6 +13,11 @@
 		--tw-prose-quote-borders: #ff0000;
 	}
 
+	body {
+		scrollbar-width: auto;
+    		scrollbar-color: rgb(77, 77, 77) rgb(40, 40, 45);
+	}
+
 	html,
 	body,
 	body > div {


### PR DESCRIPTION
I noticed on he video you posted, the scrollbars appeared white and a bit out of place given the dark theme on the UI. This should do the trick to make them more subtle if that's something you're looking for. Looking absolutely awesome though!