### PR TITLE
Typo fixed in login.ts

### DIFF
--- a/apps/web/src/lib/utils/login.ts
+++ b/apps/web/src/lib/utils/login.ts
@@ -109,7 +109,7 @@ export async function login(
 				const loadNip07Interval = setInterval(async () => {
 					if (window.nostr) {
 						clearInterval(loadNip07Interval);
-						const user = nip07SignIn(ndk);
+						const user = nip07SignIn($ndk);
 						// await finalizeLogin();
 						resolve(user);
 					}


### PR DESCRIPTION
nip07SignIn argument should be an `ndk` instance, not a store.